### PR TITLE
implement messages used by new protos

### DIFF
--- a/pydem/messages.py
+++ b/pydem/messages.py
@@ -720,6 +720,7 @@ class BaselineFlags(enum.IntFlag):
     SCALE = (1<<3)
 
 
+@dataclasses.dataclass
 class SpawnStaticMessage:
     ID = 20
 


### PR DESCRIPTION
With this branch pydem can now parse and write demos produced by, for example, arcane dimensions.  Tested with a demo on `ad_sepulcher`.  I checked that `pydem.py demo.dem` produces a demo that exactly matches the input.